### PR TITLE
follow flake-compat input for deduplication

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,12 @@
 (import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    nodeName = lock.nodes.root.inputs.flake-compat;
+  in
   fetchTarball {
-    url = "https://github.com/edolstra/flake-compat/archive/12c64ca55c1014cdc1b16ed5a804aa8576601ff2.tar.gz";
-    sha256 = "0jm6nzb83wa6ai17ly9fzpqc40wg1viib8klq8lby54agpl213w5";
+    url =
+      lock.nodes.${nodeName}.locked.url
+        or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.${nodeName}.locked.rev}.tar.gz";
+    sha256 = lock.nodes.${nodeName}.locked.narHash;
   }
-) {
-  src = ./.;
-}).defaultNix
+) { src = ./.; }).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1732722421,
+        "narHash": "sha256-HRJ/18p+WoXpWJkcdsk9St5ZiukCqSDgbOGFa8Okehg=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "9ed2ac151eada2306ca8c418ebd97807bb08f6ac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1720657034,
@@ -18,6 +34,7 @@
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -4,9 +4,13 @@
   inputs = {
     # Pinned to align the version of VS Codium with Cursor's build.
     nixpkgs.url = "github:NixOS/nixpkgs/212defe037698e18fc9521dfe451779a8979844c";
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
   };
 
-  outputs = { self, nixpkgs }:
+  outputs = { self, nixpkgs, ...}:
     let
       supportedSystems = [ "aarch64-linux" "armv7l-linux" "x86_64-linux" ];
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
@@ -105,7 +109,7 @@
                 cp ${cursorSrc}/cursor.png $out/cursor.png
                 cp ${cursorSrc}/cursor.desktop $out/cursor.desktop
                 cp -R ${cursorSrc}/resources/todesktop* $out/resources/
-                
+
                 # This is excluded intentionally. It causes an error in console,
                 # but there's some token we must be missing?
                 # cp ${cursorSrc}/resources/app-update.yml $out/resources/


### PR DESCRIPTION
Changes the non-flakes compatibility interface so that it follows the URL of flake-compat from `flake.nix` instead of a manually specified rev/hash in order to:

1. Allow overriding flake-compat URL to deduplicate inputs while consuming cursor-arm as a flake input
2. Updating `flake-compat` alongside other dependencies without manually changing the revision and hash.

Fully compatible with non-flakes since it merely parses the `flake.lock`.